### PR TITLE
remove yaml-rust warning via config/db migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,8 +159,7 @@ dependencies = [
  "scopeguard",
  "semver 1.0.27",
  "serde",
- "serde_yaml 0.8.26",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "solana-clap-utils",
  "solana-config-interface",
  "solana-hash 4.2.0",
@@ -422,7 +421,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "solana-account",
  "solana-account-decoder",
  "solana-accounts-db",
@@ -4462,12 +4461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5217,7 +5210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c53a5ade47760e8cc4986bdc5e72daeffaaaee64cbc374f9cfe0a00c1cd87b1f"
 dependencies = [
  "serde",
- "serde_yaml 0.8.26",
+ "serde_json",
 ]
 
 [[package]]
@@ -6597,18 +6590,6 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.3",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
@@ -7658,7 +7639,7 @@ dependencies = [
  "anyhow",
  "dirs-next",
  "serde",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "solana-clap-utils",
  "solana-commitment-config",
  "url 2.5.8",
@@ -8560,7 +8541,7 @@ dependencies = [
  "itertools 0.14.0",
  "serde",
  "serde_json",
- "serde_yaml 0.9.34+deprecated",
+ "serde_yaml",
  "solana-account",
  "solana-bls-signatures",
  "solana-borsh",
@@ -11224,6 +11205,8 @@ dependencies = [
  "indicatif",
  "pickledb",
  "serde",
+ "serde_json",
+ "serde_yaml",
  "solana-account-decoder",
  "solana-clap-utils",
  "solana-cli-config",
@@ -13843,15 +13826,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.14",
  "rustix 0.38.39",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/install/Cargo.toml
+++ b/install/Cargo.toml
@@ -33,7 +33,6 @@ scopeguard = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_yaml = { workspace = true }
-serde_yaml_08 = { package = "serde_yaml", version = "0.8.26" }
 solana-clap-utils = { workspace = true }
 solana-config-interface = { version = "=2.0.0", features = ["bincode"] }
 solana-hash = "=4.2.0"

--- a/install/src/config.rs
+++ b/install/src/config.rs
@@ -1,6 +1,6 @@
 use {
     crate::update_manifest::UpdateManifest,
-    serde::{Deserialize, Serialize},
+    serde::{Deserialize, Deserializer, Serialize},
     solana_pubkey::Pubkey,
     std::{
         fs::{File, create_dir_all},
@@ -9,10 +9,44 @@ use {
     },
 };
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+#[derive(Serialize, Debug, PartialEq, Eq)]
 pub enum ExplicitRelease {
     Semver(String),
     Channel(String),
+}
+
+impl<'de> Deserialize<'de> for ExplicitRelease {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        enum TaggedExplicitRelease {
+            Semver(String),
+            Channel(String),
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum ExplicitReleaseRepr {
+            Tagged(TaggedExplicitRelease),
+            LegacySemver {
+                #[serde(rename = "Semver")]
+                semver: String,
+            },
+            LegacyChannel {
+                #[serde(rename = "Channel")]
+                channel: String,
+            },
+        }
+
+        match ExplicitReleaseRepr::deserialize(deserializer)? {
+            ExplicitReleaseRepr::Tagged(TaggedExplicitRelease::Semver(value))
+            | ExplicitReleaseRepr::LegacySemver { semver: value } => Ok(Self::Semver(value)),
+            ExplicitReleaseRepr::Tagged(TaggedExplicitRelease::Channel(value))
+            | ExplicitReleaseRepr::LegacyChannel { channel: value } => Ok(Self::Channel(value)),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq)]
@@ -25,9 +59,6 @@ pub struct Config {
     pub releases_dir: PathBuf,
     active_release_dir: PathBuf,
 }
-
-const LEGACY_FMT_LOAD_ERR: &str =
-    "explicit_release: invalid type: map, expected a YAML tag starting with '!'";
 
 impl Config {
     pub fn new(
@@ -49,46 +80,7 @@ impl Config {
 
     fn _load(config_file: &str) -> Result<Self, io::Error> {
         let file = File::open(config_file)?;
-        serde_yaml::from_reader(file).or_else(|err| {
-            let err_string = format!("{err:?}");
-            if err_string.contains(LEGACY_FMT_LOAD_ERR) {
-                // looks like a config written by serde_yaml <0.9.0.
-                // let's try to upgrade it
-                Self::try_migrate_08(config_file).map_err(|_| io::Error::other(err_string))
-            } else {
-                Err(io::Error::other(err_string))
-            }
-        })
-    }
-
-    fn try_migrate_08(config_file: &str) -> Result<Self, io::Error> {
-        eprintln!("attempting to upgrade legacy config file");
-        let bak_filename = config_file.to_string() + ".bak";
-        std::fs::copy(config_file, &bak_filename)?;
-        let result = File::open(config_file).and_then(|file| {
-            serde_yaml_08::from_reader(file)
-                .map_err(|err| io::Error::other(format!("{err:?}")))
-                .and_then(|config_08: Self| {
-                    let save = config_08._save(config_file).map(|_| config_08);
-                    if save.is_ok() {
-                        let _ = std::fs::remove_file(&bak_filename);
-                    }
-                    save
-                })
-        });
-        if result.is_err() {
-            eprintln!("config upgrade failed! restoring original");
-            let restored = std::fs::copy(&bak_filename, config_file)
-                .and_then(|_| std::fs::remove_file(&bak_filename));
-            if restored.is_err() {
-                eprintln!("restoration failed! original: `{bak_filename}`");
-            } else {
-                eprintln!("restoration succeeded!");
-            }
-        } else {
-            eprintln!("config upgrade succeeded!");
-        }
-        result
+        serde_yaml::from_reader(file).map_err(|err| io::Error::other(format!("{err:?}")))
     }
 
     pub fn load(config_file: &str) -> Result<Self, String> {

--- a/tokens/Cargo.toml
+++ b/tokens/Cargo.toml
@@ -23,8 +23,10 @@ csv = { workspace = true }
 ctrlc = { workspace = true, features = ["termination"] }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
-pickledb = { workspace = true, features = ["yaml"] }
+pickledb = { workspace = true, features = ["json"] }
 serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 solana-account-decoder = { workspace = true }
 solana-clap-utils = { workspace = true }
 solana-cli-config = { workspace = true }

--- a/tokens/src/db.rs
+++ b/tokens/src/db.rs
@@ -7,7 +7,7 @@ use {
     solana_signature::Signature,
     solana_transaction::Transaction,
     solana_transaction_status::TransactionStatus,
-    std::{cmp::Ordering, fs, io, path::Path},
+    std::{cmp::Ordering, collections::HashMap, fs, io, path::Path},
 };
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -50,21 +50,42 @@ impl Default for TransactionInfo {
 }
 
 pub fn open_db(path: &str, dry_run: bool) -> Result<PickleDb, Error> {
-    let policy = if dry_run {
-        PickleDbDumpPolicy::NeverDump
-    } else {
-        PickleDbDumpPolicy::DumpUponRequest
+    let policy = || {
+        if dry_run {
+            PickleDbDumpPolicy::NeverDump
+        } else {
+            PickleDbDumpPolicy::DumpUponRequest
+        }
     };
     let path = Path::new(path);
     let db = if path.exists() {
-        PickleDb::load_yaml(path, policy)?
+        match PickleDb::load_json(path, policy()) {
+            Ok(db) => db,
+            Err(err) => {
+                // Legacy DBs were YAML-backed; migrate them to JSON on read.
+                if migrate_legacy_yaml_db(path).is_ok() {
+                    PickleDb::load_json(path, policy())?
+                } else {
+                    return Err(err);
+                }
+            }
+        }
     } else {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent).unwrap();
         }
-        PickleDb::new_yaml(path, policy)
+        PickleDb::new_json(path, policy())
     };
     Ok(db)
+}
+
+fn migrate_legacy_yaml_db(path: &Path) -> io::Result<()> {
+    let file = fs::read_to_string(path)?;
+    let db: (HashMap<String, String>, HashMap<String, Vec<String>>) =
+        serde_yaml::from_str(&file).map_err(io::Error::other)?;
+    let json = serde_json::to_string(&db).map_err(io::Error::other)?;
+    fs::write(path, json)?;
+    Ok(())
 }
 
 pub fn compare_transaction_infos(a: &TransactionInfo, b: &TransactionInfo) -> Ordering {
@@ -249,7 +270,7 @@ mod tests {
     #[test]
     fn test_write_transaction_log() {
         let mut db =
-            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+            PickleDb::new_json(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
@@ -273,7 +294,7 @@ mod tests {
     fn test_update_finalized_transaction_not_landed() {
         // Keep waiting for a transaction that hasn't landed yet.
         let mut db =
-            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+            PickleDb::new_json(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
@@ -305,7 +326,7 @@ mod tests {
     fn test_update_finalized_transaction_confirming() {
         // Keep waiting for a transaction that is still being confirmed.
         let mut db =
-            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+            PickleDb::new_json(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
@@ -333,7 +354,7 @@ mod tests {
     fn test_update_finalized_transaction_failed() {
         // Don't wait if the transaction failed to execute.
         let mut db =
-            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+            PickleDb::new_json(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();
@@ -358,7 +379,7 @@ mod tests {
     fn test_update_finalized_transaction_finalized() {
         // Don't wait once the transaction has been finalized.
         let mut db =
-            PickleDb::new_yaml(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
+            PickleDb::new_json(NamedTempFile::new().unwrap(), PickleDbDumpPolicy::NeverDump);
         let signature = Signature::default();
         let transaction_info = TransactionInfo::default();
         db.set(&signature.to_string(), &transaction_info).unwrap();


### PR DESCRIPTION
## Summary
- remove `serde_yaml_08` from `agave-install`
- preserve legacy `explicit_release` config loading by adding backward-compatible deserialization
- switch `solana-tokens` PickleDB from YAML to JSON
- add one-time migration that rewrites legacy YAML token DB files to JSON on first load

## Validation
- `CARGO_HOME=/home/trent/agave/.cargo-home cargo check -p agave-install -p solana-tokens`
- `CARGO_HOME=/home/trent/agave/.cargo-home cargo test -p agave-install test_load_serde_yaml_v_0_8_config -- --nocapture`
- `cargo audit --json` (no `yaml-rust` warning remains)

## Notes
- Kept separate from the prior `backoff` warning fix branch as requested.
